### PR TITLE
Update dockerfile to ruby 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.3
+ARG ruby_version=3.4
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
We already use ruby 3.4 features (particularly `it` as a block parameter), so the app won't work on 3.3