### PR TITLE
Disconnect databases before puma forks

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,2 +1,23 @@
 require "govuk_app_config/govuk_puma"
 GovukPuma.configure_rails(self)
+
+before_fork do |_server|
+  # Disconnect all databases before forking, otherwise the forked processes
+  # will mess up their parent's database connection file descriptors.
+  Thread.current[:sequel_connect_options] = Sequel::DATABASES.map do |db|
+    db.disconnect
+    db.opts[:orig_opts]
+  end
+
+  # Copied from GovukPuma.configure_rails
+  next unless ENV["GOVUK_APP_ROOT"]
+
+  ENV["BUNDLE_GEMFILE"] = "#{ENV['GOVUK_APP_ROOT']}/Gemfile"
+end
+
+on_worker_boot do
+  # If the parent of this fork was connected to any databases, reconnect
+  Thread.current[:sequel_connect_options].each do |opts|
+    Sequel.connect(opts)
+  end
+end


### PR DESCRIPTION
As suggested here:

    https://github.com/TalentBox/sequel-rails/issues/81#issuecomment-299740864

GOV.UK uses preload_app! so Puma loads application code before forking.

The issue is that the postgres connection uses file descriptors, which are copied over to new processes when puma forks to create new workers. These new workers then trample over each others connections, because they're all shared with each other and the parent.

Sequel recommends disconnecting before forking, and reestablishing connections when the workers boot. Hopefully this should resolve the pg disconnect errors I've been seeing when this is deployed to integration.