### PR TITLE
Implement api_path and friends

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -31,7 +31,20 @@ module Types
     field :last_edited_by_editor_id, String, null: true
     field :content_id, String, null: false
 
+    field :api_path, String, null: false
+    def api_path = "/api/content#{object[:base_path]}".chomp("/")
+
+    field :api_url, String, null: false
+    def api_url = "#{website_root}/api/content#{object[:base_path]}".chomp("/")
+
+    field :web_url, String, null: false
+    def web_url = "#{website_root}#{object[:base_path]}".chomp("/")
+
     field :links, LinksType
     field :locale, String, null: false
+
+    def website_root
+      ENV.fetch("GOVUK_WEBSITE_ROOT", "https://www.gov.uk")
+    end
   end
 end

--- a/lib/graphql_query_builder.rb
+++ b/lib/graphql_query_builder.rb
@@ -5,9 +5,6 @@ require "json"
 class GraphqlQueryBuilder
   # FIELDS_TO_IGNORE is a bit of a "to do" list really. We should implement these:
   FIELDS_TO_IGNORE = %w[
-    api_path
-    api_url
-    web_url
     withdrawn
     publishing_scheduled_at
     scheduled_publishing_delay_seconds


### PR DESCRIPTION
These exist on content-store responses, so it's convenient for comparison purposes to expose them throug this API as well.