### PR TITLE
Support graphql aliases on links_of_type

### DIFF
--- a/app/graphql/types/links_type.rb
+++ b/app/graphql/types/links_type.rb
@@ -1,7 +1,7 @@
 module Types
   class LinksType < Types::BaseObject
     field :available_translations, [EditionType], null: true
-    field :links_of_type, [EditionType] do
+    field :links_of_type, [EditionType], extras: [:ast_node] do
       argument :type, String, required: true
       argument :reverse, Boolean, default_value: false
     end
@@ -30,7 +30,10 @@ module Types
     end
 
     # rubocop:disable Lint/UnusedMethodArgument
-    def links_of_type(type:, reverse:) = object.dig(:links, type)
+    def links_of_type(type:, reverse:, ast_node:)
+      key = ast_node.alias || type
+      object.dig(:links, key)
+    end
     # rubocop:enable Lint/UnusedMethodArgument
   end
 end

--- a/app/models/expanded_edition_dataset.rb
+++ b/app/models/expanded_edition_dataset.rb
@@ -8,8 +8,8 @@ class ExpandedEditionDataset
     db = Sequel::Model.db
 
     paths_from_json_sql = <<~SQL
-      SELECT path, next, columns
-      FROM json_to_recordset(?) AS paths(path text[], next text, columns jsonb)
+      SELECT path, next, next_alias, columns
+      FROM json_to_recordset(?) AS paths(path text[], next text, next_alias text, columns jsonb)
     SQL
 
     state_filter = ["published", ("draft" if include_drafts), ("unpublished" if include_withdrawn)].compact
@@ -34,7 +34,7 @@ class ExpandedEditionDataset
       *PathTreeHelpers::ALL_EDITION_COLUMNS.without(:state).map { Sequel[:editions][it] },
     ].compact
     child_selections = [
-      Sequel[:edition_links][:path].pg_array.push(Sequel[:link_type].cast(:text)).as(:path),
+      Sequel[:edition_links][:path].pg_array.push(Sequel[:next_alias]).as(:path),
       Sequel[:edition_links][:id_path].pg_array.push(Sequel[:editions][:id]).as(:id_path),
       Sequel[:documents][:content_id].as(:content_id),
       Sequel[:documents][:id].as(:document_id),

--- a/lib/path_tree_helpers.rb
+++ b/lib/path_tree_helpers.rb
@@ -43,8 +43,9 @@ module PathTreeHelpers
 
   def self.build_path(raw_path)
     {
-      path: raw_path[0...-1].map { it[:type] },
+      path: raw_path[0...-1].map { it[:alias] || it[:type] },
       next: raw_path.last[:type],
+      next_alias: raw_path.last[:alias] || raw_path.last[:type],
       columns: raw_path.last[:columns],
     }
   end
@@ -60,6 +61,8 @@ module PathTreeHelpers
   def self.build_segment(selection)
     segment = {}
     segment = segment.merge(selection.arguments)
+    selection.ast_nodes.map(&:alias) => [ selection_alias ]
+    segment = segment.merge({ alias: selection_alias }) if selection_alias.present?
     segment.merge({ columns: (selection.selections.map(&:name).to_set & ALL_EDITION_COLUMNS).index_with(true) })
   end
 

--- a/test/lib/path_tree_helpers_test.rb
+++ b/test/lib/path_tree_helpers_test.rb
@@ -5,30 +5,33 @@ require_relative "../../lib/path_tree_helpers"
 require_relative "../test_helper"
 
 class PathTreeHelpersTest < Minitest::Test
-  Selection = Data.define(:name, :arguments, :selections)
+  AstNode = Data.define(:alias)
+  Selection = Data.define(:name, :ast_nodes, :arguments, :selections)
+
   def test_extract_paths
+    ast_nodes = [AstNode.new(alias: nil)]
     lookahead = Minitest::Mock.new
     lookahead.expect :selections, [
-      Selection.new(name: :links, arguments: {}, selections: [
-        Selection.new(name: :links_of_type, arguments: { name: "person" }, selections: [
-          Selection.new(name: :base_path, arguments: {}, selections: []),
-          Selection.new(name: :title, arguments: {}, selections: []),
-          Selection.new(name: :links, arguments: {}, selections: [
-            Selection.new(name: :links_of_type, arguments: { name: "person", reverse: true }, selections: [
-              Selection.new(name: :base_path, arguments: {}, selections: []),
-              Selection.new(name: :title, arguments: {}, selections: []),
-              Selection.new(name: :links, arguments: {}, selections: [
-                Selection.new(name: :links_of_type, arguments: { name: "role" }, selections: [
-                  Selection.new(name: :base_path, arguments: {}, selections: []),
-                  Selection.new(name: :title, arguments: {}, selections: []),
+      Selection.new(name: :links, ast_nodes:, arguments: {}, selections: [
+        Selection.new(name: :links_of_type, ast_nodes:, arguments: { name: "person" }, selections: [
+          Selection.new(name: :base_path, ast_nodes: [], arguments: {}, selections: []),
+          Selection.new(name: :title, ast_nodes:, arguments: {}, selections: []),
+          Selection.new(name: :links, ast_nodes:, arguments: {}, selections: [
+            Selection.new(name: :links_of_type, ast_nodes:, arguments: { name: "person", reverse: true }, selections: [
+              Selection.new(name: :base_path, ast_nodes:, arguments: {}, selections: []),
+              Selection.new(name: :title, ast_nodes:, arguments: {}, selections: []),
+              Selection.new(name: :links, ast_nodes:, arguments: {}, selections: [
+                Selection.new(name: :links_of_type, ast_nodes:, arguments: { name: "role" }, selections: [
+                  Selection.new(name: :base_path, ast_nodes:, arguments: {}, selections: []),
+                  Selection.new(name: :title, ast_nodes:, arguments: {}, selections: []),
                 ]),
               ]),
             ]),
           ]),
         ]),
-        Selection.new(name: :links_of_type, arguments: { name: "organisation" }, selections: [
-          Selection.new(name: :base_path, arguments: {}, selections: []),
-          Selection.new(name: :title, arguments: {}, selections: []),
+        Selection.new(name: :links_of_type, ast_nodes:, arguments: { name: "organisation" }, selections: [
+          Selection.new(name: :base_path, ast_nodes:, arguments: {}, selections: []),
+          Selection.new(name: :title, ast_nodes:, arguments: {}, selections: []),
         ]),
       ]),
     ]


### PR DESCRIPTION
In some queries, we have:

    parent_taxons: links_of_type(type: "parent_taxon")
    child_taxons: links_of_type(type: "parent_taxon", reverse: true)

Which means that link type isn't enough to disambiguate one from the other. The alias has to be unique, so we can use that instead of the link type as the path key.

This means we have to mess around with ast_nodes a bit, which is ugly. But this whole implementation is ugly so `¯\_(ツ)_/¯`