### PR TITLE
Add support for embedded editions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "~> 8.0.1"
 gem "graphql", "~> 2.4"
 
 gem "bootsnap", require: false
+gem "content_block_tools", "~> 0.4"
 gem "gds-api-adapters", "~> 98.2"
 gem "gds-sso", "~> 19.1"
 gem "govspeak", "~> 10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
+    content_block_tools (0.4.4)
+      actionview (>= 6)
     crass (1.0.6)
     csv (3.3.2)
     date (3.4.1)
@@ -655,6 +657,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
+  content_block_tools (~> 0.4)
   csv
   debug
   gds-api-adapters (~> 98.2)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TODO list
 - [x] Implement a content-store shim
 - [x] Implement a compare-with-content-store endpoint using hashdiff
 - [x] Support non-english locales in content-store-shim
-- [ ] Implement embedded editions
+- [x] Implement embedded editions
 - [ ] Come up with a nicer way to handle taxons and parents
 - [ ] Refactor to use database views to simplify recursive CTE
 - [ ] Refactor so the code is vaguely understandable and maintainable

--- a/app/graphql/queries/guide.graphql
+++ b/app/graphql/queries/guide.graphql
@@ -25,6 +25,14 @@ query guide($base_path: String!, $locale: String!) {
         web_url
         withdrawn
       }
+      embed: links_of_type(type: "embed") {
+        document_type
+        content_id
+        title
+        details {
+          json
+        }
+      }
       mainstream_browse_pages: links_of_type(type: "mainstream_browse_pages") {
         api_path
         api_url

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -31,10 +31,7 @@ module Types
     field :details, Types::DetailsType, null: false
     def details = object[:details]
                     &.symbolize_keys
-                    &.merge(
-                      document_id: object[:document_id],
-                      user_facing_version: object[:user_facing_version],
-                    )
+                    &.merge(parent: object)
 
     field :routes, GraphQL::Types::JSON, null: true
     field :redirects, GraphQL::Types::JSON, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -89,6 +89,7 @@ type Details {
   international_delegations: JSON
   introduction: JSON
   introductory_paragraph: JSON
+  json: JSON!
   key: JSON
   label: JSON
   label_text: JSON
@@ -226,40 +227,45 @@ type Edition {
   base_path: String
   content_id: String!
   content_store: String!
-  created_at: String!
+  created_at: ISO8601DateTime!
   description: String
   details: Details!
   document_id: Int!
   document_type: String!
-  first_published_at: String
+  first_published_at: ISO8601DateTime
   id: Int!
-  last_edited_at: String
+  last_edited_at: ISO8601DateTime
   last_edited_by_editor_id: String
   links: Links
   locale: String!
-  major_published_at: String
+  major_published_at: ISO8601DateTime
   phase: String
-  public_updated_at: String!
-  published_at: String
-  publishing_api_first_published_at: String
-  publishing_api_last_edited_at: String
+  public_updated_at: ISO8601DateTime!
+  published_at: ISO8601DateTime
+  publishing_api_first_published_at: ISO8601DateTime
+  publishing_api_last_edited_at: ISO8601DateTime
   publishing_app: String!
   publishing_request_id: String
-  publishing_scheduled_at: String
+  publishing_scheduled_at: ISO8601DateTime
   redirects: JSON
   rendering_app: String!
   routes: JSON
-  scheduled_publishing_delay_seconds: String
+  scheduled_publishing_delay_seconds: Int
   schema_name: String!
   state: String!
   title: String!
   update_type: String
-  updated_at: String!
-  user_facing_version: String
+  updated_at: ISO8601DateTime!
+  user_facing_version: Int
   web_url: String!
   withdrawn: Boolean!
   withdrawn_notice: JSON!
 }
+
+"""
+An ISO 8601-encoded datetime
+"""
+scalar ISO8601DateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
 
 """
 Represents untyped JSON


### PR DESCRIPTION
... only adding to the guide query at this point. Eventually we'd need to add embed to all the schemas that support them.