### PR TITLE
Add configuration for `govuk_dependabot_merger`

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,7 @@
+api_version: 2
+defaults:
+  allowed_semver_bumps:
+    - patch
+    - minor
+  auto_merge: true
+  update_external_dependencies: true


### PR DESCRIPTION
This will allow minor and patch releases of dependencies to be merged automatically, reducing the number of alerts presented to the Publishing Platform team.

Depends on https://github.com/alphagov/govuk-dependabot-merger/pull/92.