### PR TITLE
Fix ministers index path building

### DIFF
--- a/lib/path_tree_helpers.rb
+++ b/lib/path_tree_helpers.rb
@@ -61,7 +61,7 @@ module PathTreeHelpers
   def self.build_segment(selection)
     segment = {}
     segment = segment.merge(selection.arguments)
-    selection.ast_nodes.map(&:alias) => [ selection_alias ]
+    selection.ast_nodes.map(&:alias).uniq => [ selection_alias ]
     segment = segment.merge({ alias: selection_alias }) if selection_alias.present?
     segment.merge({ columns: (selection.selections.map(&:name).to_set & ALL_EDITION_COLUMNS).index_with(true) })
   end


### PR DESCRIPTION
The hacky bit of code that uses ast_nodes assumes that there will only be one node per selection. For role_appointments in the ministers index query I was trying, there are two nodes, both with alias role_appointments.

I don't really understand why this is, but I don't want to just take the first one as that could hide a gnarly bug. Calling uniq allows me to ignore this situation, but the code will still blow up in future if another situation where multiple ast_nodes appear comes up.