### PR TITLE
Add connection_validator extension

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module GovukGraphql
 
     config.sequel.after_connect = proc do
       Sequel.extension :pg_array_ops
-      Sequel::Model.db.extension :pg_json, :pg_array
+      Sequel::Model.db.extension :pg_json, :pg_array, :connection_validator
     end
   end
 end


### PR DESCRIPTION
Because non-production databases get reset overnight, we end up with broken connections first thing in the morning. These result in Sequel::DatabaseDisconnectError for the first few requests of the day (enough time to clear out the connection pool of broken connections). Connection validator should automatically check these connections when they're used after a timeout of ~1 hour, which should prevent the early morning errors.