### PR TITLE
PP-623 Support localised Govspeak

### DIFF
--- a/app/graphql/types/details_type.rb
+++ b/app/graphql/types/details_type.rb
@@ -126,7 +126,10 @@ module Types
 
       govspeak_doc = case intro_para.map(&:deep_symbolize_keys)
                      in [*, { content_type: "text/govspeak", content: String => body }, *]
-                       Govspeak::Document.new(body, { attachments: object[:attachments] })
+                       Govspeak::Document.new(body, {
+                         attachments: object[:attachments],
+                         locale: object.dig(:parent, :locale),
+                       })
                      end
 
       govspeak_doc.send(:kramdown_doc).as_json.dig("root", "children").map(&method(:compact_and_select_kramdown_fields))
@@ -280,7 +283,10 @@ module Types
              in [*, { content_type: "text/html", content: String => body }, *]
                body
              in [*, { content_type: "text/govspeak", content: String => body }, *]
-               Govspeak::Document.new(body, { attachments: object[:attachments] }).to_html
+               Govspeak::Document.new(body, {
+                 attachments: object[:attachments],
+                 locale: object.dig(:parent, :locale),
+               }).to_html
              end
 
       embeds = object.dig(:parent, :links, "embed")


### PR DESCRIPTION
Govspeak supports localisation of static content for some components, like footnote and image caption labels, devolved content, and contacts. However, we need to tell Govspeak what locale to use in order to opt in to this feature

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/PP/boards/333?selectedIssue=PP-623)